### PR TITLE
style: fix feedback dialog textarea max width and implement auto-resizing textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.0.9]
+fix feedback dialog textarea max width and implement auto-resizing textarea
+
 ## [2.0.8]
 update toast styles
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pstrack",
-  "version": "2.0.10",
+  "version": "2.1.10",
   "private": false,
   "license": "MIT",
   "author": {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = '2.0.10'
+export const VERSION = '2.1.10'
 export const VISIBLE_COUNT = 20
 export const PROBLEM_BASE_URL = 'https://leetcode.com/problems'
 export const LEETCODE_GQL_BASE_URL = 'https://leetcode.com/graphql'

--- a/src/ui/textarea.tsx
+++ b/src/ui/textarea.tsx
@@ -10,7 +10,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
       textarea.style.height = `${textarea.scrollHeight}px`
     }
   }
-  
+
   return (
     <textarea
       ref={textareaRef}

--- a/src/ui/textarea.tsx
+++ b/src/ui/textarea.tsx
@@ -1,11 +1,23 @@
 import { cn } from '@/utils/cn'
+import { useRef } from 'react'
 
 function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const resizeTextarea = () => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = 'auto'
+      textarea.style.height = `${textarea.scrollHeight}px`
+    }
+  }
+  
   return (
     <textarea
+      ref={textareaRef}
+      onInput={resizeTextarea}
       data-slot="textarea"
       className={cn(
-        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex max-h-40 min-h-16 w-full resize-none overflow-x-hidden rounded-md border bg-transparent px-3 py-2 text-base break-words shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className
       )}
       {...props}


### PR DESCRIPTION
This pull request introduces a fix for the feedback dialog's textarea by implementing an auto-resizing functionality and setting a maximum width. It also updates the changelog to reflect these changes.

### Textarea improvements:

* [`src/ui/textarea.tsx`](diffhunk://#diff-2be26f163b872def32d52dc776e5546c527285e2114395f6a39bfdc271c65fa4R2-R20): Added a `useRef` hook to manage the textarea reference and implemented an `onInput` handler (`resizeTextarea`) to dynamically adjust the textarea's height based on its content. Updated the CSS classes to make the textarea non-resizable (`resize-none`) and limit its height (`max-h-40`).

### Documentation update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5): Added an entry for version `2.0.9` to document the fix for the feedback dialog's textarea, including the auto-resizing functionality.